### PR TITLE
Fix translate workflow: stage before diff check

### DIFF
--- a/.github/workflows/translate.yml
+++ b/.github/workflows/translate.yml
@@ -40,12 +40,12 @@ jobs:
 
       - name: Commit translations
         run: |
-          if git diff --quiet; then
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add 'src/content/blog/**/en.mdx'
+          if git diff --staged --quiet; then
             echo "No translation changes."
             exit 0
           fi
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add src/content/blog/**/en.mdx
           git commit -m "chore: auto-translate posts [skip ci]"
           git push


### PR DESCRIPTION
Untracked en.mdx files were invisible to `git diff --quiet`, so the commit step bailed early with "No translation changes" even after 19 successful translations. Stage first, then check the staged diff.