### PR TITLE
fix: escape MDX-unsafe characters in translated posts

### DIFF
--- a/scripts/translate.mjs
+++ b/scripts/translate.mjs
@@ -36,7 +36,13 @@ Rules:
 - Translate image alt text inside markdown image syntax.
 - Preserve all markdown structure: headings, lists, blockquotes, line breaks.
 - Keep informal tone if the source is informal; technical accuracy matters.
-- The body uses MDX. Leave any JSX expressions untouched.
+
+The body output is MDX (NOT plain markdown). MDX parses JSX, so unescaped \`<\`, \`>\`, and \`{\`/\`}\` in prose can break the build. In prose (NOT inside code blocks or inline code), escape these:
+- A \`<\` that is not the start of a real HTML/JSX tag — e.g. \`<3\` (heart), \`<5\` ("less than 5"), \`< 100ms\`, \`a < b\`. Write them as \`&lt;\` (so \`<3\` → \`&lt;3\`).
+- A \`>\` used as a comparison (\`a > b\`, \`> 50%\`) when it could be confused with a tag close. When in doubt, use \`&gt;\`. Do NOT escape \`>\` at the start of a line — that is a markdown blockquote.
+- Literal curly braces \`{\` / \`}\` in prose — escape as \`\\{\` and \`\\}\` so MDX does not treat them as JSX expressions.
+Inside code blocks (fenced or inline) leave all characters as-is — never escape there.
+Leave existing JSX expressions and HTML/MDX tags untouched.
 
 If the user provides a "previousEnglish" object alongside the French source, treat it as a baseline:
 - Re-use its existing wording verbatim wherever the French is unchanged in meaning.

--- a/src/content/blog/copy-nfc-card/en.mdx
+++ b/src/content/blog/copy-nfc-card/en.mdx
@@ -124,7 +124,7 @@ There you go!
 
 During the day, a test with the Chinese copy confirms that everything works correctly, the canteen turnstile doesn’t notice a thing 🔥
 
-## Thanks <3
+## Thanks &lt;3
 
 Even though I first started this project alone, I owe a huge thank you to Romain, who spent long hours with me finding solutions to the various problems I encountered!
 

--- a/src/content/blog/root-oneplus/en.mdx
+++ b/src/content/blog/root-oneplus/en.mdx
@@ -59,7 +59,7 @@ Next, we need to reboot the phone and redo all the updates to get back to Androi
 
 Now, we need to flash the Custom ROM.
 
-I chose Evolution X, which builds on the Pixel Experience by adding many nice options. Huge thanks to **lahaina** who has maintained this ROM for the OnePlus Nord 2 since its release <3
+I chose Evolution X, which builds on the Pixel Experience by adding many nice options. Huge thanks to **lahaina** who has maintained this ROM for the OnePlus Nord 2 since its release &lt;3
 
 ### Boot into FastbootD
 


### PR DESCRIPTION
## Summary
- Cloudflare build was failing on `src/content/blog/copy-nfc-card/en.mdx:127` because `## Thanks <3` is parsed as a malformed JSX tag by MDX (the original `index.md` is plain markdown so the `<3` was fine there).
- Replace `<3` with `&lt;3` so the site builds again.
- Harden the translate prompt in `scripts/translate.mjs` so future auto-translations escape `<`, `>`, and `{}` in prose — with explicit examples (`<3`, `<5`, `< 100ms`, `a < b`) and exceptions for code blocks and blockquote `>`.

## Test plan
- [x] `npm run build` passes locally
- [ ] Cloudflare Pages build goes green on this branch
- [ ] Next auto-translate run does not reintroduce raw `<digit` / `<space` patterns in prose