### PR TITLE
feat: feature Insomnihack 2025 CTF write-up

### DIFF
--- a/src/content/blog/insomnihack-25-unchained/index.md
+++ b/src/content/blog/insomnihack-25-unchained/index.md
@@ -4,6 +4,7 @@ date: 2025-03-15
 image: ./insomnihack.png
 imageAlt: Insomnihack
 lang: fr
+featured: true
 ---
 
 Un write-up du challenge Unchained du CTF Insomnihack, lequel a lieu tous les ans au Swiss Tech Center à l'EPFL.


### PR DESCRIPTION
## Summary
- Add `featured: true` to `src/content/blog/insomnihack-25-unchained/index.md` so the CTF write-up appears with the "À la une" / "Featured" badge alongside `copy-nfc-card`.

## Test plan
- [x] Frontmatter parses (only added one line)
- [ ] Verify the post shows the badge on `/` and `/en/` after deploy