### PR TITLE
feat: shrink site fonts ~10%

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -22,11 +22,15 @@ body {
   padding: 0;
 }
 
+html {
+  font-size: 90%;
+}
+
 body {
   font-family:
     system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto,
     'Helvetica Neue', sans-serif;
-  font-size: 18px;
+  font-size: 16.2px;
   line-height: 1.5;
   color: var(--text);
   background: var(--background);
@@ -91,7 +95,7 @@ pre {
   border-radius: 10px;
   padding: 16px;
   overflow-x: auto;
-  font-size: 10px;
+  font-size: 9px;
   line-height: 1.4;
 }
 


### PR DESCRIPTION
## Summary
Reduce overall font size by ~10% across the site:
- `html { font-size: 90%; }` so all rem-based sizes (header, footer, lang toggle, alternate-lang note, blog post small print) shrink proportionally.
- `body` base font-size: `18px` → `16.2px`.
- `pre` code font-size: `10px` → `9px`.

Layout dimensions (main width, padding) intentionally left alone — only fonts.

## Test plan
- [x] Build passes locally
- [ ] Visual check on `/`, `/en/`, and a blog post on the deployed site