### PR TITLE
chore: stop ignoring public/ (gatsby leftover)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,7 +56,6 @@ typings/
 
 # gatsby files
 .cache/
-public
 
 # Mac files
 .DS_Store


### PR DESCRIPTION
## Summary
The repo migrated from Gatsby to Astro. In Gatsby, `public/` was a build-output directory and rightfully gitignored. In Astro, `public/` is the **source-of-truth** for static assets — its contents get copied verbatim into `dist/` — so it must be tracked.

The 5 asset files moved to `public/` in #14 only got staged because `git mv` preserves tracking through ignore rules. Any *new* files added with plain `mv` are silently ignored, which is what bit us when adding the aer-lingus assets.

## Test plan
- [x] `git check-ignore -v public/some-file` no longer reports the `public` rule
- [ ] Future `git add public/...` works as expected